### PR TITLE
Fix installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Simply download the toolkit and copy the desired scripts into your Mochimo Node'
 
 ```bash
 git clone https://github.com/chrisdigity/mochitoolkit.git ~/mochitoolkit
-cp -r ~/mochitoolkit/scripts ~/mochi/
+mkdir ~/mochi
+cp -r ~/mochitoolkit/scripts ~/mochi
 ```
 
 ## Bugs


### PR DESCRIPTION
Result before: `~/mochitoolkit/mauto`.
Result after: `~/mochitoolkit/scripts/mauto`.

Sometimes (when `~/mochi` didn't exist?) it copied files straight to `~/mochi`, ommiting creation of `scripts` subdirectory.